### PR TITLE
Relax protection modifiers to enable subclassing

### DIFF
--- a/src/FluentModbus/ModbusFrameBuffer.cs
+++ b/src/FluentModbus/ModbusFrameBuffer.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace FluentModbus
 {
-    internal class ModbusFrameBuffer : IDisposable
+    public class ModbusFrameBuffer : IDisposable
     {
         #region Constructors
 

--- a/src/FluentModbus/Server/ModbusRequestHandler.cs
+++ b/src/FluentModbus/Server/ModbusRequestHandler.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace FluentModbus
 {
-    internal abstract class ModbusRequestHandler : IDisposable
+    public abstract class ModbusRequestHandler : IDisposable
     {
         #region Fields
 
@@ -41,7 +41,7 @@ namespace FluentModbus
 
         protected byte UnitIdentifier { get; set; }
         protected CancellationTokenSource CTS { get; }
-        protected ModbusFrameBuffer FrameBuffer { get; }
+        public ModbusFrameBuffer FrameBuffer { get; }
 
         protected abstract bool IsResponseRequired { get; }
 
@@ -116,7 +116,7 @@ namespace FluentModbus
             this.OnResponseReady(frameLength);
         }
 
-        internal abstract Task ReceiveRequestAsync();
+        public abstract Task ReceiveRequestAsync();
 
         protected void Start()
         {

--- a/src/FluentModbus/Server/ModbusRtuRequestHandler.cs
+++ b/src/FluentModbus/Server/ModbusRtuRequestHandler.cs
@@ -38,7 +38,7 @@ namespace FluentModbus
 
         #region Methods
 
-        internal override async Task ReceiveRequestAsync()
+        public override async Task ReceiveRequestAsync()
         {
             if (this.CTS.IsCancellationRequested)
                 return;

--- a/src/FluentModbus/Server/ModbusRtuServer.cs
+++ b/src/FluentModbus/Server/ModbusRtuServer.cs
@@ -149,7 +149,7 @@ namespace FluentModbus
             this.RequestHandler = new ModbusRtuRequestHandler(serialPort, this);
         }
 
-        private protected override void ProcessRequests()
+        protected override void ProcessRequests()
         {
             lock (this.Lock)
             {

--- a/src/FluentModbus/Server/ModbusServer.cs
+++ b/src/FluentModbus/Server/ModbusServer.cs
@@ -294,7 +294,7 @@ namespace FluentModbus
             }
         }
 
-        private protected abstract void ProcessRequests();
+        protected abstract void ProcessRequests();
 
         #endregion
 

--- a/src/FluentModbus/Server/ModbusTcpRequestHandler.cs
+++ b/src/FluentModbus/Server/ModbusTcpRequestHandler.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace FluentModbus
 {
-    internal class ModbusTcpRequestHandler : ModbusRequestHandler, IDisposable
+    public class ModbusTcpRequestHandler : ModbusRequestHandler, IDisposable
     {
         #region Fields
 
@@ -21,7 +21,7 @@ namespace FluentModbus
 
         #region Constructors
 
-        public ModbusTcpRequestHandler(TcpClient tcpClient, ModbusTcpServer tcpServer) : base(tcpServer, 260)
+        public ModbusTcpRequestHandler(TcpClient tcpClient, ModbusServer server) : base(server, 260)
         {
             _tcpClient = tcpClient;
             _networkStream = tcpClient.GetStream();
@@ -43,7 +43,7 @@ namespace FluentModbus
 
         #region Methods
 
-        internal override async Task ReceiveRequestAsync()
+        public override async Task ReceiveRequestAsync()
         {
             if (this.CTS.IsCancellationRequested)
                 return;

--- a/src/FluentModbus/Server/ModbusTcpServer.cs
+++ b/src/FluentModbus/Server/ModbusTcpServer.cs
@@ -194,7 +194,7 @@ namespace FluentModbus
             this.RequestHandlers?.ForEach(requestHandler => requestHandler.Dispose());
         }
 
-        private protected override void ProcessRequests()
+        protected override void ProcessRequests()
         {
             lock (this.Lock)
             {


### PR DESCRIPTION
This PR reduces restriction on a number of classes to enable subclassing of the server component. A very simple TCP simple server can now be created with syntax like this:

```
    internal class InternalModbusServer : ModbusServer
    {
        private readonly ModbusTcpRequestHandler request;

        public InternalModbusServer(TcpClient client) : base(true)
        {
            request = new ModbusTcpRequestHandler(client, this);
        }

        protected override void ProcessRequests()
        {
            if (request.IsReady)
            {
                if (request.Length > 0)
                    request.WriteResponse();

                _ = request.ReceiveRequestAsync();
            }
        }
    }
```
This is useful for callers who have their own TcpServer implementation