### PR TITLE
Check byte count in DetectFrame method.

### DIFF
--- a/src/FluentModbus/ModbusUtils.cs
+++ b/src/FluentModbus/ModbusUtils.cs
@@ -99,7 +99,7 @@ namespace FluentModbus
             }
 
             // Byte count check
-            if (span.Length < span[2] + 5)
+            if (span[1] < 0x80 && span.Length < span[2] + 5)
                 return false;
 
             // CRC check

--- a/src/FluentModbus/ModbusUtils.cs
+++ b/src/FluentModbus/ModbusUtils.cs
@@ -98,6 +98,10 @@ namespace FluentModbus
                     return false;
             }
 
+            // Byte count check
+            if (span.Length < span[2] + 5)
+                return false;
+
             // CRC check
             var crcBytes = span.Slice(span.Length - 2, 2);
             var actualCRC = unchecked((ushort)((crcBytes[1] << 8) + crcBytes[0]));


### PR DESCRIPTION
Hello @Apollo3zehn,

I have found an issue with the current logic of how the Modbus RTU frame is detected. This issue occurs under seldom circumstances, let me share an example.

We have a temperature sensor with unit identifier 1 providing data thru input register 0. The corresponding Modbus request frame is `01 04 00 00 00 01 31 CA`. Response frames depend on the actual temperature getting as Celsius degrees multiplied by 100. However, there is a special value that we must focus on: 7.69 degrees. The Modbus response frame for value 769 is `01 04 02 03 01 78 00`.

The `DetectFrame` method is called from the response [pump](https://github.com/Apollo3zehn/FluentModbus/blob/a55249c45159f62999eb5b641c9a6bca2bfc8bb7/src/FluentModbus/Client/ModbusRtuClient.cs#L192). Our sensor returns a frame as entirely (7 bytes) as divided into segments (e.g. 6+1 bytes). The described issue occurs when the `DetectFrame` method is called for the response frame mentioned in the previous paragraph without the last byte (6-byte incomplete segment).

Theoretically, such trimmed frames should be identified in `DetectFrame` due to relying on CRC. Unfortunately, the CRC-based check is not enough for this particular case. Look at the discussed response frame trimmed to `01 04 02 03 01 78`. The frame-detection code treats this frame as successfully detected because sequence `01 04 02 03` generates CRC `0x7801`. Obviously, `01 04 02 03 01 78` is incomplete by the standard because it indicates 2 bytes of data in the third byte but it has only one data byte.

So I have added a couple of lines into the method to additionally check the byte count field declared by the Modbus RTU specification.