### PR TITLE
Only connect TcpClient if not already connected

### DIFF
--- a/src/FluentModbus/Client/ModbusTcpClient.cs
+++ b/src/FluentModbus/Client/ModbusTcpClient.cs
@@ -167,7 +167,7 @@ namespace FluentModbus
 
             _tcpClient = (tcpClient, isInternal);
 
-            if (!tcpClient.ConnectAsync(remoteEndpoint.Address, remoteEndpoint.Port).Wait(ConnectTimeout))
+            if (!IsConnected && !tcpClient.ConnectAsync(remoteEndpoint.Address, remoteEndpoint.Port).Wait(ConnectTimeout)) 
                 throw new Exception(ErrorMessage.ModbusClient_TcpConnectTimeout);
 
             _networkStream = tcpClient.GetStream();


### PR DESCRIPTION
It appears we missed this one, but Connect needs to be called otherwise  _frameBuffer and _networkStream etc won't get set.