### PR TITLE
fix two modbus rtu problems

### DIFF
--- a/src/FluentModbus/ModbusRtuSerialPort.cs
+++ b/src/FluentModbus/ModbusRtuSerialPort.cs
@@ -76,10 +76,8 @@ namespace FluentModbus
             /* _serialPort.DiscardInBuffer is essential here to cancel the operation */
             using (timeoutCts.Token.Register(() =>
                    {
-                       if (this.IsOpen)
-                       {
+                       if (IsOpen)
                            _serialPort.DiscardInBuffer();
-                       }
                    }))
             using (token.Register(() => timeoutCts.Cancel()))
             {

--- a/src/FluentModbus/ModbusRtuSerialPort.cs
+++ b/src/FluentModbus/ModbusRtuSerialPort.cs
@@ -74,7 +74,13 @@ namespace FluentModbus
             using var timeoutCts = new CancellationTokenSource(_serialPort.ReadTimeout);
 
             /* _serialPort.DiscardInBuffer is essential here to cancel the operation */
-            using (timeoutCts.Token.Register(() => _serialPort.DiscardInBuffer()))
+            using (timeoutCts.Token.Register(() =>
+                   {
+                       if (this.IsOpen)
+                       {
+                           _serialPort.DiscardInBuffer();
+                       }
+                   }))
             using (token.Register(() => timeoutCts.Cancel()))
             {
                 try

--- a/src/FluentModbus/Server/ModbusRtuRequestHandler.cs
+++ b/src/FluentModbus/Server/ModbusRtuRequestHandler.cs
@@ -110,7 +110,6 @@ namespace FluentModbus
             catch (TimeoutException)
             {
                 Length = 0;
-                UnitIdentifier = 255;
             }
 
             // make sure that the incoming frame is actually adressed to this server

--- a/src/FluentModbus/Server/ModbusRtuRequestHandler.cs
+++ b/src/FluentModbus/Server/ModbusRtuRequestHandler.cs
@@ -110,6 +110,7 @@ namespace FluentModbus
             catch (TimeoutException)
             {
                 Length = 0;
+                UnitIdentifier = 255;
             }
 
             // make sure that the incoming frame is actually adressed to this server

--- a/src/FluentModbus/Server/ModbusRtuServer.cs
+++ b/src/FluentModbus/Server/ModbusRtuServer.cs
@@ -161,7 +161,7 @@ namespace FluentModbus
         /// <summary>
         /// Stops the server and closes the underlying serial port.
         /// </summary>
-        public void Stop()
+        public override void Stop()
         {
             base.StopProcessing();
 

--- a/src/FluentModbus/Server/ModbusServer.cs
+++ b/src/FluentModbus/Server/ModbusServer.cs
@@ -302,13 +302,13 @@ namespace FluentModbus
         /// </summary>
         public virtual void Stop()
         {
-            this.StopProcessing();
+            StopProcessing();
         }
 
         /// <summary>
         /// Stops the server operation.
         /// </summary>
-        public virtual void StopProcessing()
+        protected virtual void StopProcessing()
         {
             CTS?.Cancel();
             _manualResetEvent?.Set();

--- a/src/FluentModbus/Server/ModbusServer.cs
+++ b/src/FluentModbus/Server/ModbusServer.cs
@@ -298,6 +298,14 @@ namespace FluentModbus
         }
 
         /// <summary>
+        /// Stops the server operation and cleans up all resources.
+        /// </summary>
+        public virtual void Stop()
+        {
+            this.StopProcessing();
+        }
+
+        /// <summary>
         /// Stops the server operation.
         /// </summary>
         public virtual void StopProcessing()

--- a/src/FluentModbus/Server/ModbusServer.cs
+++ b/src/FluentModbus/Server/ModbusServer.cs
@@ -308,7 +308,7 @@ namespace FluentModbus
         /// <summary>
         /// Stops the server operation.
         /// </summary>
-        protected virtual void StopProcessing()
+        protected void StopProcessing()
         {
             CTS?.Cancel();
             _manualResetEvent?.Set();

--- a/src/FluentModbus/Server/ModbusServer.cs
+++ b/src/FluentModbus/Server/ModbusServer.cs
@@ -308,7 +308,7 @@ namespace FluentModbus
         /// <summary>
         /// Stops the server operation.
         /// </summary>
-        protected void StopProcessing()
+        protected virtual void StopProcessing()
         {
             CTS?.Cancel();
             _manualResetEvent?.Set();

--- a/src/FluentModbus/Server/ModbusTcpServer.cs
+++ b/src/FluentModbus/Server/ModbusTcpServer.cs
@@ -211,7 +211,7 @@ namespace FluentModbus
         /// <summary>
         /// Stops the server and closes all open TCP connections.
         /// </summary>
-        public void Stop()
+        public override void Stop()
         {
             base.StopProcessing();
 


### PR DESCRIPTION
When a ModbusRtuRequestHandler is Disposed it closes the SerialPort before the CancellationTokenSource of the base class is cancelled. Therefor the InBuffer of SerialPort should be cleared even if the serialport is already closed.
Secondly on a timeout exception the UnitIdentifier should be reset otherwise an exception is thrown.