### PR TITLE
Add option for raising event even if values of buffer have not changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v5.0.2 - 2023-08-03
+## v5.0.3 - 2023-08-03
 
 - The Modbus TCP server now returns the received unit identifier even when its own unit identifier is set to zero (the default) (solves #93).
 - The protected methods `AddUnit()` and `RemoveUnit()` have been made public.

--- a/src/FluentModbus/Server/ModbusRequestHandler.cs
+++ b/src/FluentModbus/Server/ModbusRequestHandler.cs
@@ -187,18 +187,31 @@ namespace FluentModbus
         {
             Span<int> changedRegisters = stackalloc int[newValues.Length];
 
-            var index = 0;
+            var length = 0;
 
-            for (int i = 0; i < newValues.Length; i++)
+            if (ModbusServer.AlwaysRaiseChangedEvent) 
             {
-                if (newValues[i] != oldValues[i] || ModbusServer.AlwaysRaiseChangedEvent)
+                for (int i = 0; i < newValues.Length; i++)
                 {
-                    changedRegisters[index] = startingAddress + i;
-                    index++;
+                    changedRegisters[length] = startingAddress + i;
+                }
+
+                length = newValues.Length;
+            }
+
+            else
+            {
+                for (int i = 0; i < newValues.Length; i++)
+                {
+                    if (newValues[i] != oldValues[i])
+                    {
+                        changedRegisters[length] = startingAddress + i;
+                        length++;
+                    }
                 }
             }
 
-            ModbusServer.OnRegistersChanged(UnitIdentifier, changedRegisters.Slice(0, index).ToArray());
+            ModbusServer.OnRegistersChanged(UnitIdentifier, changedRegisters.Slice(0, length).ToArray());
         }
 
         // class 0

--- a/src/FluentModbus/Server/ModbusRequestHandler.cs
+++ b/src/FluentModbus/Server/ModbusRequestHandler.cs
@@ -191,7 +191,7 @@ namespace FluentModbus
 
             for (int i = 0; i < newValues.Length; i++)
             {
-                if (newValues[i] != oldValues[i])
+                if (newValues[i] != oldValues[i] || ModbusServer.AlwaysRaiseChangedEvent)
                 {
                     changedRegisters[index] = startingAddress + i;
                     index++;
@@ -352,7 +352,7 @@ namespace FluentModbus
 
                     coils[bufferByteIndex] = newValue;
 
-                    if (ModbusServer.EnableRaisingEvents && newValue != oldValue)
+                    if (ModbusServer.EnableRaisingEvents && (newValue != oldValue || ModbusServer.AlwaysRaiseChangedEvent))
                         ModbusServer.OnCoilsChanged(UnitIdentifier, new int[] { outputAddress });
 
                     FrameBuffer.Writer.Write((byte)ModbusFunctionCode.WriteSingleCoil);
@@ -379,7 +379,7 @@ namespace FluentModbus
                 var newValue = registerValue;
                 holdingRegisters[registerAddress] = newValue;
 
-                if (ModbusServer.EnableRaisingEvents && newValue != oldValue)
+                if (ModbusServer.EnableRaisingEvents && (newValue != oldValue || ModbusServer.AlwaysRaiseChangedEvent))
                     ModbusServer.OnRegistersChanged(UnitIdentifier, new int[] { registerAddress });
 
                 FrameBuffer.Writer.Write((byte)ModbusFunctionCode.WriteSingleRegister);

--- a/src/FluentModbus/Server/ModbusRequestHandler.cs
+++ b/src/FluentModbus/Server/ModbusRequestHandler.cs
@@ -194,9 +194,8 @@ namespace FluentModbus
                 for (int i = 0; i < newValues.Length; i++)
                 {
                     changedRegisters[length] = startingAddress + i;
+                    length++;
                 }
-
-                length = newValues.Length;
             }
 
             else

--- a/src/FluentModbus/Server/ModbusServer.cs
+++ b/src/FluentModbus/Server/ModbusServer.cs
@@ -148,6 +148,11 @@ namespace FluentModbus
         /// </summary>
         public bool EnableRaisingEvents { get; set; }
 
+        /// <summary>
+        /// Trigger the RegisterChanged or CoilsChanged event even when value has not been updated. Default: false.
+        /// </summary>
+        public bool AlwaysRaiseChangedEvent { get; set; } = false;
+
         internal bool IsSingleZeroUnitMode => UnitIdentifiers.Count == 1 && UnitIdentifiers[0] == 0;
 
         private protected CancellationTokenSource CTS { get; private set; } = new CancellationTokenSource();

--- a/src/FluentModbus/Server/ModbusServer.cs
+++ b/src/FluentModbus/Server/ModbusServer.cs
@@ -149,7 +149,7 @@ namespace FluentModbus
         public bool EnableRaisingEvents { get; set; }
 
         /// <summary>
-        /// Trigger the RegisterChanged or CoilsChanged event even when value has not been updated. Default: false.
+        /// Trigger the RegistersChanged or CoilsChanged event even when value has not been updated. Default: false.
         /// </summary>
         public bool AlwaysRaiseChangedEvent { get; set; } = false;
 


### PR DESCRIPTION
I have a need to listen to events that are kicked by the server when values have been written, even if values have not been updated. I tried using RequestValidator but because that happens before values are written to registers there seemed to be no reliable way of knowing the value that is being written.