### PR TITLE
Added broadcast support to ModbusTcpClient

### DIFF
--- a/src/FluentModbus/Client/ModbusTcpClient.cs
+++ b/src/FluentModbus/Client/ModbusTcpClient.cs
@@ -36,6 +36,12 @@ namespace FluentModbus
         #region Properties
 
         /// <summary>
+        /// Gets or sets the gateway mode flag.
+        /// If set to true it enables the use of the unit identifier 0 for modbus broadcasts.
+        /// </summary>
+        public bool RTUGatewayMode { get; set; }
+
+        /// <summary>
         /// Gets or sets the connect timeout in milliseconds. Default is 1000 ms.
         /// </summary>
         public int ConnectTimeout { get; set; } = ModbusTcpClient.DefaultConnectTimeout;
@@ -226,11 +232,11 @@ namespace FluentModbus
             reader = _frameBuffer.Reader;
 
             // build request
-            if (!(0 <= unitIdentifier && unitIdentifier <= 247))
+            if (RTUGatewayMode && !(0 <= unitIdentifier && unitIdentifier <= 247))
                 throw new ModbusException(ErrorMessage.ModbusClient_InvalidUnitIdentifier);
 
             // special case: broadcast (only for write commands)
-            if (unitIdentifier == 0)
+            if (RTUGatewayMode && unitIdentifier == 0)
             {
                 switch (functionCode)
                 {
@@ -271,7 +277,7 @@ namespace FluentModbus
             _networkStream.Write(frameBuffer.Buffer, 0, frameLength);
 
             // special case: broadcast (only for write commands)
-            if (unitIdentifier == 0)
+            if (RTUGatewayMode && unitIdentifier == 0)
                 return _frameBuffer.Buffer.AsSpan(0, 0);
 
             // wait for and process response

--- a/src/FluentModbus/Client/ModbusTcpClientAsync.cs
+++ b/src/FluentModbus/Client/ModbusTcpClientAsync.cs
@@ -29,11 +29,11 @@ namespace FluentModbus
             reader = _frameBuffer.Reader;
 
             // build request
-            if (!(0 <= unitIdentifier && unitIdentifier <= 247))
+            if (RTUGatewayMode && !(0 <= unitIdentifier && unitIdentifier <= 247))
                 throw new ModbusException(ErrorMessage.ModbusClient_InvalidUnitIdentifier);
 
             // special case: broadcast (only for write commands)
-            if (unitIdentifier == 0)
+            if (RTUGatewayMode && unitIdentifier == 0)
             {
                 switch (functionCode)
                 {
@@ -74,7 +74,7 @@ namespace FluentModbus
             await _networkStream.WriteAsync(frameBuffer.Buffer, 0, frameLength, cancellationToken).ConfigureAwait(false);
 
             // special case: broadcast (only for write commands)
-            if (unitIdentifier == 0)
+            if (RTUGatewayMode && unitIdentifier == 0)
                 return _frameBuffer.Buffer.AsMemory(0, 0);
 
             // wait for and process response

--- a/tests/FluentModbus.Tests/ModbusTcpClientTests.cs
+++ b/tests/FluentModbus.Tests/ModbusTcpClientTests.cs
@@ -1,36 +1,89 @@
 using System.Diagnostics;
 using Xunit;
 
-namespace FluentModbus.Tests
+namespace FluentModbus.Tests;
+
+public class ModbusTcpClientTests : IClassFixture<XUnitFixture>
 {
-    public class ModbusTcpClientTests : IClassFixture<XUnitFixture>
+    [Fact]
+    public void ClientRespectsConnectTimeout()
     {
-        [Fact]
-        public void ClientRespectsConnectTimeout()
+        // Arrange
+        var endpoint = EndpointSource.GetNext();
+        var connectTimeout = 500;
+
+        var client = new ModbusTcpClient()
         {
-            // Arrange
-            var endpoint = EndpointSource.GetNext();
-            var connectTimeout = 500;
+            ConnectTimeout = connectTimeout
+        };
 
-            var client = new ModbusTcpClient()
-            {
-                ConnectTimeout = connectTimeout
-            };
+        // Act
+        var sw = Stopwatch.StartNew();
 
-            // Act
-            var sw = Stopwatch.StartNew();
-
-            try
-            {
-                client.Connect(endpoint);
-            }
-            catch (Exception)
-            {
-                // Assert
-                var elapsed = sw.ElapsedMilliseconds;
-
-                Assert.True(elapsed < connectTimeout * 2, "The connect timeout is not respected.");
-            }
+        try
+        {
+            client.Connect(endpoint);
         }
+        catch (Exception)
+        {
+            // Assert
+            var elapsed = sw.ElapsedMilliseconds;
+
+            Assert.True(elapsed < connectTimeout * 2, "The connect timeout is not respected.");
+        }
+    }
+
+    [Fact]
+    public void ClientCanUseBroadcastUnitIdentifier()
+    {
+        // Arrange
+        var endpoint = EndpointSource.GetNext();
+        
+        using var server = new ModbusTcpServer();
+        server.Start(endpoint);
+
+        var client = new ModbusTcpClient();
+        client.Connect(endpoint);
+
+        // Act
+        client.WriteSingleCoil(unitIdentifier: 0, default, default);
+    }
+
+    [Theory]
+    [InlineData(247)]
+    [InlineData(0xFF)]
+    public void ClientCanUseValidUnitIdentifier(byte unitIdentifier)
+    {
+        // Arrange
+        var endpoint = EndpointSource.GetNext();
+        
+        using var server = new ModbusTcpServer();
+        server.Start(endpoint);
+
+        var client = new ModbusTcpClient();
+        client.Connect(endpoint);
+
+        // Act
+        client.ReadHoldingRegisters(unitIdentifier, default, default);
+    }
+
+    [Theory]
+    [InlineData(248)]
+    [InlineData(254)]
+    public void ClientCannotUseInvalidUnitIdentifier(byte unitIdentifier)
+    {
+        // Arrange
+        var endpoint = EndpointSource.GetNext();
+        
+        using var server = new ModbusTcpServer();
+        server.Start(endpoint);
+
+        var client = new ModbusTcpClient();
+        client.Connect(endpoint);
+
+        void action() => client.ReadHoldingRegisters(unitIdentifier, default, default);
+
+        // Act / Assert
+        Assert.Throws<ModbusException>(action);
     }
 }


### PR DESCRIPTION
The ModbusTcpClient missed the support for broadcast messages.
I copied the two code parts from the ModbusRtuClient into the ModbusTcpClient.