### PR TITLE
Make IsConnected an abstract member of ModbusClient

### DIFF
--- a/src/FluentModbus/Client/ModbusClient.cs
+++ b/src/FluentModbus/Client/ModbusClient.cs
@@ -10,6 +10,11 @@ namespace FluentModbus
     {
         #region Properties
 
+        /// <summary>
+        /// Gets the connection status of the underlying client.
+        /// </summary>
+        public abstract bool IsConnected { get; }
+        
         protected private bool SwapBytes { get; set; }
 
         #endregion

--- a/src/FluentModbus/Client/ModbusRtuClient.cs
+++ b/src/FluentModbus/Client/ModbusRtuClient.cs
@@ -31,7 +31,7 @@ namespace FluentModbus
         /// <summary>
         /// Gets the connection status of the underlying serial port.
         /// </summary>
-        public bool IsConnected => _serialPort?.Value.IsOpen ?? false;
+        public override bool IsConnected => _serialPort?.Value.IsOpen ?? false;
 
         /// <summary>
         /// Gets or sets the serial baud rate. Default is 9600.

--- a/src/FluentModbus/Client/ModbusTcpClient.cs
+++ b/src/FluentModbus/Client/ModbusTcpClient.cs
@@ -36,6 +36,11 @@ namespace FluentModbus
         #region Properties
 
         /// <summary>
+        /// Gets the connection status of the underlying TCP client.
+        /// </summary>
+        public override bool IsConnected => _tcpClient?.Value.Connected ?? false;
+        
+        /// <summary>
         /// Gets or sets the connect timeout in milliseconds. Default is 1000 ms.
         /// </summary>
         public int ConnectTimeout { get; set; } = ModbusTcpClient.DefaultConnectTimeout;
@@ -55,11 +60,6 @@ namespace FluentModbus
         #endregion
 
         #region Methods
-
-        /// <summary>
-        /// Gets the connection status of the underlying TCP client.
-        /// </summary>
-        public bool IsConnected => _tcpClient?.Value.Connected ?? false;
 
         /// <summary>
         /// Connect to localhost at port 502 with <see cref="ModbusEndianness.LittleEndian"/> as default byte layout.


### PR DESCRIPTION
This is useful in code where you reference a `ModbusClient` and don't care if it is TCP or RTU.