### PR TITLE
Expose DisplayName to RequestValidator

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -408,12 +408,12 @@ It might happen that a server should not support all Modbus functions or only a 
 
 var server = new ModbusTcpServer()
 {
-    RequestValidator = (unitIdentifier, functionCode, address, quantityOfRegisters) =>
+    RequestValidator = (args) =>
     {
-        if (functionCode == ModbusFunctionCode.WriteSingleRegister)
+        if (args.FunctionCode == ModbusFunctionCode.WriteSingleRegister)
             return ModbusExceptionCode.IllegalFunction;
 
-        else if (address < 5 || address > 15)
+        else if (args.Address < 5 || args.Address > 15)
             return ModbusExceptionCode.IllegalDataAddress;
 
         else

--- a/doc/index.md
+++ b/doc/index.md
@@ -408,7 +408,7 @@ It might happen that a server should not support all Modbus functions or only a 
 
 var server = new ModbusTcpServer()
 {
-    RequestValidator = (args) =>
+    RequestValidator = args =>
     {
         if (args.FunctionCode == ModbusFunctionCode.WriteSingleRegister)
             return ModbusExceptionCode.IllegalFunction;

--- a/doc/samples/modbus_validator.md
+++ b/doc/samples/modbus_validator.md
@@ -8,21 +8,17 @@ var server = new ModbusTcpServer()
     RequestValidator = this.ModbusValidator;
 };
 
-private ModbusExceptionCode ModbusValidator(
-    byte unitIdentifier,
-    ModbusFunctionCode functionCode, 
-    ushort address, 
-    ushort quantityOfRegisters)
+private ModbusExceptionCode ModbusValidator(RequestValidatorArgs args)
 {
     // check if address is within valid holding register limits
-    var holdingLimits = (address >= 50 && address < 90) ||
-                         address >= 2000 && address < 2100;
+    var holdingLimits = (args.Address >= 50 && args.Address < 90) ||
+                         args.Address >= 2000 && args.Address < 2100;
 
     // check if address is within valid input register limits
-    var inputLimits = address >= 1000 && address < 2000;
+    var inputLimits = args.Address >= 1000 && args.Address < 2000;
 
     // go through all cases and return proper response
-    return (functionCode, holdingLimits, inputLimits) switch
+    return (args.FunctionCode, holdingLimits, inputLimits) switch
     {
         // holding registers
         (ModbusFunctionCode.ReadHoldingRegisters, true, _)          => ModbusExceptionCode.OK,

--- a/doc/samples/modbus_validator.md
+++ b/doc/samples/modbus_validator.md
@@ -11,8 +11,8 @@ var server = new ModbusTcpServer()
 private ModbusExceptionCode ModbusValidator(RequestValidatorArgs args)
 {
     // check if address is within valid holding register limits
-    var holdingLimits = (args.Address >= 50 && args.Address < 90) ||
-                         args.Address >= 2000 && args.Address < 2100;
+    var holdingLimits = args.Address >= 50 && args.Address < 90 ||
+                        args.Address >= 2000 && args.Address < 2100;
 
     // check if address is within valid input register limits
     var inputLimits = args.Address >= 1000 && args.Address < 2000;

--- a/src/FluentModbus/Server/ModbusRequestHandler.cs
+++ b/src/FluentModbus/Server/ModbusRequestHandler.cs
@@ -159,7 +159,14 @@ internal abstract class ModbusRequestHandler : IDisposable
     {
         if (ModbusServer.RequestValidator is not null)
         {
-            var result = ModbusServer.RequestValidator(UnitIdentifier, functionCode, address, quantityOfRegisters);
+            var result = ModbusServer.RequestValidator(new RequestValidatorArgs
+            {
+                UnitIdentifier = UnitIdentifier,
+                Address = address,
+                QuantityOfRegisters = quantityOfRegisters,
+                FunctionCode = functionCode,
+                ConnectionName = DisplayName
+            });
 
             if (result > ModbusExceptionCode.OK)
             {

--- a/src/FluentModbus/Server/ModbusServer.cs
+++ b/src/FluentModbus/Server/ModbusServer.cs
@@ -37,6 +37,37 @@ public readonly struct CoilsChangedEventArgs
 }
 
 /// <summary>
+/// Provides data for the Request Validator
+/// </summary>
+public readonly struct RequestValidatorArgs
+{
+    /// <summary>
+    /// The unit identifier for the request.
+    /// </summary>
+    public byte UnitIdentifier { get; init; }
+    
+    /// <summary>
+    /// Modbus function code.
+    /// </summary>
+    public ModbusFunctionCode FunctionCode { get; init; }
+    
+    /// <summary>
+    /// Address of the first register or coil to read or write.
+    /// </summary>
+    public ushort Address { get; init; }
+    
+    /// <summary>
+    /// Quantity of registers or coils to read or write.
+    /// </summary>
+    public ushort QuantityOfRegisters { get; init; }
+    
+    /// <summary>
+    /// DisplayName of the connection that is requesting the data.
+    /// </summary>
+    public string ConnectionName { get; init; }
+}
+
+/// <summary>
 /// Base class for a Modbus server.
 /// </summary>
 public abstract class ModbusServer : IDisposable
@@ -144,7 +175,7 @@ public abstract class ModbusServer : IDisposable
     /// <summary>
     /// Gets or sets a method that validates each client request.
     /// </summary>
-    public Func<byte, ModbusFunctionCode, ushort, ushort, ModbusExceptionCode>? RequestValidator { get; set; }
+    public Func<RequestValidatorArgs, ModbusExceptionCode>? RequestValidator { get; set; }
 
     /// <summary>
     /// Gets or sets whether the events should be raised when register or coil data changes. Default: false.

--- a/src/FluentModbus/Server/ModbusServer.cs
+++ b/src/FluentModbus/Server/ModbusServer.cs
@@ -37,7 +37,7 @@ public readonly struct CoilsChangedEventArgs
 }
 
 /// <summary>
-/// Provides data for the Request Validator
+/// Provides data for the request validator.
 /// </summary>
 public readonly struct RequestValidatorArgs
 {

--- a/tests/FluentModbus.Tests/ModbusServerTests.cs
+++ b/tests/FluentModbus.Tests/ModbusServerTests.cs
@@ -176,12 +176,12 @@ public class ModbusServerTests : IClassFixture<XUnitFixture>
 
         using var server = new ModbusTcpServer()
         {
-            RequestValidator = (unitIdentifier, functionCode, address, quantityOfRegisters) =>
+            RequestValidator = (args) =>
             {
-                var holdingLimits = (address >= 50 && address < 90) ||
-                                     address >= 2000 && address < 2100;
+                var holdingLimits = (args.Address >= 50 && args.Address < 90) ||
+                                    args.Address >= 2000 && args.Address < 2100;
 
-                var inputLimits = address >= 1000 && address < 2000;
+                var inputLimits = args.Address >= 1000 && args.Address < 2000;
 
                 return (functionCode, holdingLimits, inputLimits) switch
                 {

--- a/tests/FluentModbus.Tests/ModbusServerTests.cs
+++ b/tests/FluentModbus.Tests/ModbusServerTests.cs
@@ -176,9 +176,9 @@ public class ModbusServerTests : IClassFixture<XUnitFixture>
 
         using var server = new ModbusTcpServer()
         {
-            RequestValidator = (args) =>
+            RequestValidator = args =>
             {
-                var holdingLimits = (args.Address >= 50 && args.Address < 90) ||
+                var holdingLimits = args.Address >= 50 && args.Address < 90 ||
                                     args.Address >= 2000 && args.Address < 2100;
 
                 var inputLimits = args.Address >= 1000 && args.Address < 2000;


### PR DESCRIPTION
We have a need to Validate incoming request to modbus server based on which IP address it is coming from. To do this I exposed `DisplayName` property of ModbusRequestHandler to user with `RequestValidator`. However, adding new parameter is breaking change. So I just ended up adding new args object for it, so next addition don't require changes for users of the library. There is already an issue here for similar need: #133