### PR TITLE
Fix transaction identifier collision

### DIFF
--- a/src/FluentModbus/Client/ModbusTcpClient.cs
+++ b/src/FluentModbus/Client/ModbusTcpClient.cs
@@ -219,16 +219,18 @@ public partial class ModbusTcpClient : ModbusClient, IDisposable
 
         writer.Seek(0, SeekOrigin.Begin);
 
+        var requestTransactionIdentifier = GetTransactionIdentifier();
+        
         if (BitConverter.IsLittleEndian)
         {
-            writer.WriteReverse(GetTransactionIdentifier());                // 00-01  Transaction Identifier
+            writer.WriteReverse(requestTransactionIdentifier);                // 00-01  Transaction Identifier
             writer.WriteReverse((ushort)0);                                 // 02-03  Protocol Identifier
             writer.WriteReverse((ushort)(frameLength - 6));                 // 04-05  Length
         }
 
         else
         {
-            writer.Write(GetTransactionIdentifier());                       // 00-01  Transaction Identifier
+            writer.Write(requestTransactionIdentifier);                       // 00-01  Transaction Identifier
             writer.Write((ushort)0);                                        // 02-03  Protocol Identifier
             writer.Write((ushort)(frameLength - 6));                        // 04-05  Length
         }
@@ -291,7 +293,11 @@ public partial class ModbusTcpClient : ModbusClient, IDisposable
                 if (!isParsed) // read MBAP header only once
                 {
                     // read MBAP header
-                    _ = reader.ReadUInt16Reverse();                                     // 00-01  Transaction Identifier
+                    var responseTransactionIdentifier = reader.ReadUInt16Reverse();                                     // 00-01  Transaction Identifier
+                    if (requestTransactionIdentifier != responseTransactionIdentifier)
+                    {
+                        throw new ModbusException(ErrorMessage.ModbusClient_InvalidTransactionIdentifier);
+                    }
                     var protocolIdentifier = reader.ReadUInt16Reverse();                // 02-03  Protocol Identifier               
                     bytesFollowing = reader.ReadUInt16Reverse();                        // 04-05  Length
                     _ = reader.ReadByte();                                              // 06     Unit Identifier

--- a/src/FluentModbus/Client/ModbusTcpClientAsync.cs
+++ b/src/FluentModbus/Client/ModbusTcpClientAsync.cs
@@ -15,7 +15,7 @@ public partial class ModbusTcpClient
         var frameBuffer = _frameBuffer;
         var writer = _frameBuffer.Writer;
         var reader = _frameBuffer.Reader;
-
+        
         // build request
         writer.Seek(7, SeekOrigin.Begin);
         extendFrame(writer);
@@ -23,16 +23,18 @@ public partial class ModbusTcpClient
 
         writer.Seek(0, SeekOrigin.Begin);
 
+        var requestTransactionIdentifier = GetTransactionIdentifier();
+        
         if (BitConverter.IsLittleEndian)
         {
-            writer.WriteReverse(GetTransactionIdentifier());                // 00-01  Transaction Identifier
+            writer.WriteReverse(requestTransactionIdentifier);                // 00-01  Transaction Identifier
             writer.WriteReverse((ushort)0);                                 // 02-03  Protocol Identifier
             writer.WriteReverse((ushort)(frameLength - 6));                 // 04-05  Length
         }
 
         else
         {
-            writer.Write(GetTransactionIdentifier());                       // 00-01  Transaction Identifier
+            writer.Write(requestTransactionIdentifier);                       // 00-01  Transaction Identifier
             writer.Write((ushort)0);                                        // 02-03  Protocol Identifier
             writer.Write((ushort)(frameLength - 6));                        // 04-05  Length
         }
@@ -95,10 +97,14 @@ public partial class ModbusTcpClient
                 if (!isParsed) // read MBAP header only once
                 {
                     // read MBAP header
-                    _ = reader.ReadUInt16Reverse();                                     // 00-01  Transaction Identifier
+                    var responseTransactionIdentifier = reader.ReadUInt16Reverse();     // 00-01  Transaction Identifier
+                    if (requestTransactionIdentifier != responseTransactionIdentifier)
+                    {
+                        throw new ModbusException(ErrorMessage.ModbusClient_InvalidTransactionIdentifier);
+                    }
                     var protocolIdentifier = reader.ReadUInt16Reverse();                // 02-03  Protocol Identifier               
-                    bytesFollowing = reader.ReadUInt16Reverse();                        // 04-05  Length
-                    _ = reader.ReadByte();                                              // 06     Unit Identifier
+                    bytesFollowing = reader.ReadUInt16Reverse();                              // 04-05  Length
+                    _ = reader.ReadByte();                                                    // 06     Unit Identifier
 
                     if (protocolIdentifier != 0)
                         throw new ModbusException(ErrorMessage.ModbusClient_InvalidProtocolIdentifier);

--- a/src/FluentModbus/Resources/ErrorMessage.Designer.cs
+++ b/src/FluentModbus/Resources/ErrorMessage.Designer.cs
@@ -241,6 +241,15 @@ namespace FluentModbus {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The transaction identifier is invalid..
+        /// </summary>
+        internal static string ModbusClient_InvalidTransactionIdentifier {
+            get {
+                return ResourceManager.GetString("ModbusClient_InvalidTransactionIdentifier", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The unit identifier is invalid. Valid node addresses are in the range of 0 - 247. Use address &apos;0&apos; to broadcast write command to all available servers..
         /// </summary>
         internal static string ModbusClient_InvalidUnitIdentifier {

--- a/src/FluentModbus/Resources/ErrorMessage.resx
+++ b/src/FluentModbus/Resources/ErrorMessage.resx
@@ -165,6 +165,9 @@
   <data name="ModbusClient_InvalidProtocolIdentifier" xml:space="preserve">
     <value>The protocol identifier is invalid.</value>
   </data>
+  <data name="ModbusClient_InvalidTransactionIdentifier" xml:space="preserve">
+    <value>The transaction identifier is invalid.</value>
+  </data>
   <data name="ModbusClient_InvalidResponseFunctionCode" xml:space="preserve">
     <value>The responsed function code is invalid.</value>
   </data>


### PR DESCRIPTION
It's a fix for the #146 issue. If the two transaction ID is the same, it throws an error and rebuilds the connection.