### PR TITLE
Improve TCP connect timeout handling in ModbusTcpClient

### DIFF
--- a/src/FluentModbus/Client/ModbusTcpClient.cs
+++ b/src/FluentModbus/Client/ModbusTcpClient.cs
@@ -167,8 +167,19 @@ public partial class ModbusTcpClient : ModbusClient, IDisposable
         var isInternal = remoteEndpoint is not null;
         _tcpClient = (tcpClient, isInternal);
 
-        if (remoteEndpoint is not null && !tcpClient.ConnectAsync(remoteEndpoint.Address, remoteEndpoint.Port).Wait(ConnectTimeout))
-            throw new Exception(ErrorMessage.ModbusClient_TcpConnectTimeout);
+        if (remoteEndpoint is not null)
+        {
+            var connectTask = tcpClient.ConnectAsync(remoteEndpoint.Address, remoteEndpoint.Port);
+            if (!connectTask.Wait(ConnectTimeout))
+            {
+                // Ensure the task exception is observed to avoid triggering UnobservedTaskException handlers (which can crash the process or flood logs).
+                // Attaching a continuation that accesses task.Exception guarantees the exception is observed.
+                connectTask.ContinueWith(t => t.Exception, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+                // Close the TcpClient to cancel the connection attempt.
+                tcpClient.Close();
+                throw new Exception(ErrorMessage.ModbusClient_TcpConnectTimeout);
+            }
+        }
 
         // Why no method signature with NetworkStream only and then set the timeouts 
         // in the Connect method like for the RTU client?


### PR DESCRIPTION
This pull request improves the connection logic in the `ModbusTcpClient` initialization to handle connection timeouts more robustly. The main change ensures that exceptions from failed connection attempts are properly observed, preventing potential process crashes or excessive logging.

**Connection handling improvements:**

* Updated the connection logic in `ModbusTcpClient.cs` to observe exceptions from failed `ConnectAsync` tasks by attaching a continuation that accesses `task.Exception`, ensuring unhandled exceptions do not crash the process or flood logs. Also, the `TcpClient` is explicitly closed on timeout to cancel the connection attempt.